### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/articles-v1.html
+++ b/articles-v1.html
@@ -248,7 +248,7 @@
 							</td>
 						  <td >Justifications Shape Ethical Blind Spots <a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a></td>
 						  <td ><i>Psychological Science</i></td>
-						  <td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td ><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						  <td>rs</td>
 						  <td>om</td>
 						  <td>prereg</td>
@@ -321,7 +321,7 @@
 							</td>
 							<td >Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources <a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a></td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -359,7 +359,7 @@
 							</td>
 							<td >Implicit Social Biases in People With Autism <a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a></td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -456,7 +456,7 @@
 							</td>
 							<td >Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation <a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a></td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -492,7 +492,7 @@
 							</td>
 							<td >Offenders’ uncoerced false confessions: A new application of statement analysis? <a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a></td>
 							<td ><i>Legal and Criminological Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -528,7 +528,7 @@
 							</td>
 							<td >Eliciting cues to deception by tactical disclosure of evidence: The first test of the Evidence Framing Matrix. <a href='https://rebeccawillen.files.wordpress.com/2018/02/as973445445754971400220156342_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a></td>
 							<td ><i> Legal and Criminological Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2012.02047.x">10.1111/j.2044-8333.2012.02047.x</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2012.02047.x">10.1111/j.2044-8333.2012.02047.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -574,7 +574,7 @@
 							</td>
 							<td >Self-esteem, relationship threat, and dependency regulation: Independent replication of Murray, Rose, Bellavia, Holmes, and Kusche (2002) Study 3 <a href=' https://static1.squarespace.com/static/594641bbe3df28301b1a0493/t/5970b5c8f5e2311272d3b4f0/1500558794416/2017+%28in+press%29_Campbell+et+al_JRP_Replication+of+Murray+et+al+2002.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> <span class="label label-info-purple"><a href="https://psyarxiv.com/5suda/" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td ><i>Journal of Research in Personality</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -604,7 +604,7 @@
 							</td>
 							<td >No Compelling Evidence That Preferences for Facial Masculinity Track Changes in Women’s Hormonal Status <a href='http://journals.sagepub.com/doi/pdf/10.1177/0956797618760197' target='_blank' class='sprite sprite-pdf-icon-medium'></a> <span class="label label-info-purple"><a href="https://www.biorxiv.org/content/early/2017/12/29/136549.full.pdf+html" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797618760197">10.1177/0956797618760197</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797618760197">10.1177/0956797618760197</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -624,7 +624,7 @@
 							</td>
 							<td >A test of the diffusion model explanation for the worst performance rule using preregistration and blinding <a href='https://link.springer.com/content/pdf/10.3758%2Fs13414-017-1304-y.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> <span class="label label-info-red"><a href="https://osf.io/we65f/" target="_blank" class="black" title="Go to Registered Report preregistered study protocol">Registered Report</a></span></td>
 							<td ><i>Attention, Perception, & Psychophysics</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.3758/s13414-017-1304-y">10.3758/s13414-017-1304-y</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.3758/s13414-017-1304-y">10.3758/s13414-017-1304-y</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -677,7 +677,7 @@
 							</td>
 							<td >Time, money, and happiness: Does putting a price on time affect our ability to smell the roses? <a href='http://www.scottconnors.ca/uploads/4/7/4/6/47460837/connors_khamitov_moroz_campbell_and_henderson__2016__jesp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> </td>
 							<td ><i>Journal of Experimental Social Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2015.08.005">10.1016/j.jesp.2015.08.005</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jesp.2015.08.005">10.1016/j.jesp.2015.08.005</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -748,7 +748,7 @@
 							</td>
 							<td >Does exposure to erotica reduce attraction and love for romantic partners in men? Independent replications of Kenrick, Gutierres, and Goldberg (1989) Study 2 <a href='https://www.researchgate.net/profile/Rhonda_Balzarini/publication/310488568_Does_exposure_to_erotica_reduce_attraction_and_love_for_romantic_partners_in_men_Independent_replications_of_Kenrick_Gutierres_and_Goldberg_1989_study_2/links/59cfdd434585150177ee21fd/Does-exposure-to-erotica-reduce-attraction-and-love-for-romantic-partners-in-men-Independent-replications-of-Kenrick-Gutierres-and-Goldberg-1989-study-2.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> </td>
 							<td ><i>Journal of Experimental Social Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2016.11.003">10.1016/j.jesp.2016.11.003</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jesp.2016.11.003">10.1016/j.jesp.2016.11.003</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -801,7 +801,7 @@
 							</td>
 							<td >Heightened Sensitivity to Temperature Cues in Individuals With High Anxious Attachment: Real or Elusive Phenomenon? <a href='http://etiennelebel.com/documents/l&c(2013,psci).pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> </td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797613486983">10.1177/0956797613486983</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797613486983">10.1177/0956797613486983</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -836,7 +836,7 @@
 							</td>
 							<td >Prior exposure increases perceived accuracy of fake news <a href='https://www.researchgate.net/profile/Gordon_Pennycook/publication/317069544_Implausibility_and_illusory_truth_Prior_exposure_increases_perceived_accuracy_of_fake_news_but_has_no_effect_on_entirely_implausible_statements/links/5a1dc207458515a4c3d1ad4a/Implausibility-and-illusory-truth-Prior-exposure-increases-perceived-accuracy-of-fake-news-but-has-no-effect-on-entirely-implausible-statements.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> <span class="label label-info-purple"><a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2958246" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td><i>Journal of Experimental Psychology: General</i></td>
-							<td ><a target="_blank" href="http://dx.doi.org/10.2139/ssrn.2958246">10.2139/ssrn.2958246</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.2139/ssrn.2958246">10.2139/ssrn.2958246</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -866,7 +866,7 @@
 							</td>
 							<td >Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling <a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a></td>
 							<td ><i>European Journal of Personality</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 							<td></td>
 							<td>om</td>
 							<td></td>
@@ -983,7 +983,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1177/0956797617719730' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797617719730' target='_blank'>10.1177/0956797617719730</a></td>
+  <td><a href='https://doi.org/10.1177/0956797617719730' target='_blank'>10.1177/0956797617719730</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1002,7 +1002,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/http://onlinelibrary.wiley.com/doi/pdf/10.1111/1475-679X.12198' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Journal of Accounting Research</i></td>
-  <td><a href='https://dx.doi.org/10.1111/1475-679X.12198' target='_blank'>10.1111/1475-679X.12198</a></td>
+  <td><a href='https://doi.org/10.1111/1475-679X.12198' target='_blank'>10.1111/1475-679X.12198</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1033,7 +1033,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/http://journals.sagepub.com/doi/abs/10.1177/0956797618761660?journalCode=pssa' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797618761660' target='_blank'>10.1177/0956797618761660</a></td>
+  <td><a href='https://doi.org/10.1177/0956797618761660' target='_blank'>10.1177/0956797618761660</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1052,7 +1052,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.cortex.2014.12.019' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2014.12.019' target='_blank'>10.1016/j.cortex.2014.12.019</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2014.12.019' target='_blank'>10.1016/j.cortex.2014.12.019</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1072,7 +1072,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.cortex.2016.03.004' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.004' target='_blank'>10.1016/j.cortex.2016.03.004</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.004' target='_blank'>10.1016/j.cortex.2016.03.004</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1091,7 +1091,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.cortex.2015.03.010' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2015.03.010' target='_blank'>10.1016/j.cortex.2015.03.010</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2015.03.010' target='_blank'>10.1016/j.cortex.2015.03.010</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1110,7 +1110,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.cortex.2016.01.006' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.01.006' target='_blank'>10.1016/j.cortex.2016.01.006</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.01.006' target='_blank'>10.1016/j.cortex.2016.01.006</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1131,7 +1131,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.cortex.2016.03.020' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.020' target='_blank'>10.1016/j.cortex.2016.03.020</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.020' target='_blank'>10.1016/j.cortex.2016.03.020</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1150,7 +1150,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.cortex.2016.03.019' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.019' target='_blank'>10.1016/j.cortex.2016.03.019</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.019' target='_blank'>10.1016/j.cortex.2016.03.019</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1169,7 +1169,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.cortex.2018.01.001' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2018.01.001' target='_blank'>10.1016/j.cortex.2018.01.001</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2018.01.001' target='_blank'>10.1016/j.cortex.2018.01.001</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1193,7 +1193,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://rsos.royalsocietypublishing.org/content/royopensci/3/11/160431.full.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.160431' target='_blank'>10.1098/rsos.160431</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.160431' target='_blank'>10.1098/rsos.160431</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1215,7 +1215,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://rsos.royalsocietypublishing.org/content/4/10/171172.full.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.171172' target='_blank'>10.1098/rsos.171172</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.171172' target='_blank'>10.1098/rsos.171172</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1238,7 +1238,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://rsos.royalsocietypublishing.org/content/royopensci/4/9/160935.full.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.160935' target='_blank'>10.1098/rsos.160935</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.160935' target='_blank'>10.1098/rsos.160935</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1262,7 +1262,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://rsos.royalsocietypublishing.org/content/royopensci/5/2/171678.full.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.171678' target='_blank'>10.1098/rsos.171678</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.171678' target='_blank'>10.1098/rsos.171678</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1285,7 +1285,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://rsos.royalsocietypublishing.org/content/royopensci/4/12/170543.full.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.170543' target='_blank'>10.1098/rsos.170543</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.170543' target='_blank'>10.1098/rsos.170543</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1304,7 +1304,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1177/0010414016633228' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414016633228' target='_blank'>10.1177/0010414016633228</a></td>
+  <td><a href='https://doi.org/10.1177/0010414016633228' target='_blank'>10.1177/0010414016633228</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1323,7 +1323,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1177/0010414015626436' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414015626436' target='_blank'>10.1177/0010414015626436</a></td>
+  <td><a href='https://doi.org/10.1177/0010414015626436' target='_blank'>10.1177/0010414015626436</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1342,7 +1342,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1177/0010414015621072' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414015621072' target='_blank'>10.1177/0010414015621072</a></td>
+  <td><a href='https://doi.org/10.1177/0010414015621072' target='_blank'>10.1177/0010414015621072</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1365,7 +1365,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.26030.001' target='_blank'>10.7554/eLife.26030.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.26030.001' target='_blank'>10.7554/eLife.26030.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1388,7 +1388,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.25306.001' target='_blank'>10.7554/eLife.25306.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.25306.001' target='_blank'>10.7554/eLife.25306.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1411,7 +1411,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.21253.001' target='_blank'>10.7554/eLife.21253.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.21253.001' target='_blank'>10.7554/eLife.21253.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1434,7 +1434,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.17584.001' target='_blank'>10.7554/eLife.17584.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.17584.001' target='_blank'>10.7554/eLife.17584.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1457,7 +1457,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.17044.001' target='_blank'>10.7554/eLife.17044.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.17044.001' target='_blank'>10.7554/eLife.17044.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1480,7 +1480,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.18173.001' target='_blank'>10.7554/eLife.18173.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.18173.001' target='_blank'>10.7554/eLife.18173.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1505,7 +1505,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.21634.001' target='_blank'>10.7554/eLife.21634.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.21634.001' target='_blank'>10.7554/eLife.21634.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1530,7 +1530,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.29747' target='_blank'>10.7554/eLife.29747</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.29747' target='_blank'>10.7554/eLife.29747</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1555,7 +1555,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span>
   </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.30274' target='_blank'>10.7554/eLife.30274</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.30274' target='_blank'>10.7554/eLife.30274</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1574,7 +1574,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1027/1618-3169/a000286' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000286' target='_blank'>10.1027/1618-3169/a000286</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000286' target='_blank'>10.1027/1618-3169/a000286</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1593,7 +1593,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1027/1618-3169/a000364' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000364' target='_blank'>10.1027/1618-3169/a000364</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000364' target='_blank'>10.1027/1618-3169/a000364</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1612,7 +1612,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.psychologie.hhu.de/fileadmin/redaktion/Oeffentliche_Medien/Fakultaeten/Mathematisch-Naturwissenschaftliche_Fakultaet/Psychologie/AAP/Publikationen/in_press/ExPsy.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000372' target='_blank'>10.1027/1618-3169/a000372</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000372' target='_blank'>10.1027/1618-3169/a000372</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1636,7 +1636,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='https://econtent.hogrefe.com/doi/pdf/10.1027/1864-1105/a000210' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Journal of Media Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-1105/a000210' target='_blank'>10.1027/1864-1105/a000210</a></td>
+  <td><a href='https://doi.org/10.1027/1864-1105/a000210' target='_blank'>10.1027/1864-1105/a000210</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1660,7 +1660,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1027/1864-1105/a000209' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Journal of Media Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-1105/a000209' target='_blank'>10.1027/1864-1105/a000209</a></td>
+  <td><a href='https://doi.org/10.1027/1864-1105/a000209' target='_blank'>10.1027/1864-1105/a000209</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1713,7 +1713,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4976003/pdf/nihms781195.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616649604' target='_blank'>10.1177/0956797616649604</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616649604' target='_blank'>10.1177/0956797616649604</a></td>
   <td>rs</td>
   <td></td>
   <td>prereg</td>
@@ -1746,7 +1746,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1177/0956797614553121' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797614553121' target='_blank'>10.1177/0956797614553121</a></td>
+  <td><a href='https://doi.org/10.1177/0956797614553121' target='_blank'>10.1177/0956797614553121</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1775,7 +1775,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.psych.utoronto.ca/Neuropsychologylab/PDF/Forgettingpatt.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616638307' target='_blank'>10.1177/0956797616638307</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616638307' target='_blank'>10.1177/0956797616638307</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1805,7 +1805,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1177/0956797615572909' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797615572909' target='_blank'>10.1177/0956797615572909</a></td>
+  <td><a href='https://doi.org/10.1177/0956797615572909' target='_blank'>10.1177/0956797615572909</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1828,7 +1828,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.readcube.com/articles/10.3389/fpsyg.2014.00875' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.00875' target='_blank'>10.3389/fpsyg.2014.00875</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.00875' target='_blank'>10.3389/fpsyg.2014.00875</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1850,7 +1850,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.readcube.com/articles/10.3389/fpsyg.2015.00335' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00335' target='_blank'>10.3389/fpsyg.2015.00335</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00335' target='_blank'>10.3389/fpsyg.2015.00335</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1874,7 +1874,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.readcube.com/articles/10.3389/fpsyg.2014.00786' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.00786' target='_blank'>10.3389/fpsyg.2014.00786</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.00786' target='_blank'>10.3389/fpsyg.2014.00786</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1898,7 +1898,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.readcube.com/articles/10.3389/fpsyg.2014.01035' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.01035' target='_blank'>10.3389/fpsyg.2014.01035</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.01035' target='_blank'>10.3389/fpsyg.2014.01035</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1921,7 +1921,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.readcube.com/articles/10.3389/fpsyg.2015.00672' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00672' target='_blank'>10.3389/fpsyg.2015.00672</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00672' target='_blank'>10.3389/fpsyg.2015.00672</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1945,7 +1945,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://www.readcube.com/articles/10.3389/fpsyg.2015.00494' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00494' target='_blank'>10.3389/fpsyg.2015.00494</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00494' target='_blank'>10.3389/fpsyg.2015.00494</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1966,7 +1966,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1080/23743603.2017.1341178' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2017.1341178' target='_blank'>10.1080/23743603.2017.1341178</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2017.1341178' target='_blank'>10.1080/23743603.2017.1341178</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1987,7 +1987,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1080/23743603.2017.1341186' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2017.1341186' target='_blank'>10.1080/23743603.2017.1341186</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2017.1341186' target='_blank'>10.1080/23743603.2017.1341186</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2007,7 +2007,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1080/23743603.2016.1248081' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2016.1248081' target='_blank'>10.1080/23743603.2016.1248081</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2016.1248081' target='_blank'>10.1080/23743603.2016.1248081</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2030,7 +2030,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://econtent.hogrefe.com/doi/pdf/10.1027/1864-9335/a000189' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000189' target='_blank'>10.1027/1864-9335/a000189</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000189' target='_blank'>10.1027/1864-9335/a000189</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2054,7 +2054,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://econtent.hogrefe.com/doi/pdf/10.1027/1864-9335/a000191' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000191' target='_blank'>10.1027/1864-9335/a000191</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000191' target='_blank'>10.1027/1864-9335/a000191</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2077,7 +2077,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='https://econtent.hogrefe.com/doi/pdf/10.1027/1864-9335/a000190' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000190' target='_blank'>10.1027/1864-9335/a000190</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000190' target='_blank'>10.1027/1864-9335/a000190</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2099,7 +2099,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='https://econtent.hogrefe.com/doi/pdf/10.1027/1864-9335/a000184' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000184' target='_blank'>10.1027/1864-9335/a000184</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000184' target='_blank'>10.1027/1864-9335/a000184</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2123,7 +2123,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1016/j.jrp.2017.10.005' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Journal of Research in Personality</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.jrp.2017.10.005' target='_blank'>10.1016/j.jrp.2017.10.005</a></td>
+  <td><a href='https://doi.org/10.1016/j.jrp.2017.10.005' target='_blank'>10.1016/j.jrp.2017.10.005</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2144,7 +2144,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.1080/02699931.2018.1429389' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cognition and Emotion</i></td>
-  <td><a href='https://dx.doi.org/10.1080/02699931.2018.1429389' target='_blank'>10.1080/02699931.2018.1429389</a></td>
+  <td><a href='https://doi.org/10.1080/02699931.2018.1429389' target='_blank'>10.1080/02699931.2018.1429389</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2164,7 +2164,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='https://pdfs.semanticscholar.org/8006/c4c478e994bf8681aff135f88ed95664932d.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Perception</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0301006617720831' target='_blank'>10.1177/0301006617720831</a></td>
+  <td><a href='https://doi.org/10.1177/0301006617720831' target='_blank'>10.1177/0301006617720831</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2187,7 +2187,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='https://peerj.com/articles/837.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>PeerJ</i></td>
-  <td><a href='https://dx.doi.org/10.7717/peerj.837' target='_blank'>10.7717/peerj.837</a></td>
+  <td><a href='https://doi.org/10.7717/peerj.837' target='_blank'>10.7717/peerj.837</a></td>
   <td></td>
   <td>om</td>
   <td></td>
@@ -2217,7 +2217,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://ilabs.uw.edu/sites/default/files/17Skinner_Meltzoff_Olson_Kids%20Catch%20Social%20Biases.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616678930' target='_blank'>10.1177/0956797616678930</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616678930' target='_blank'>10.1177/0956797616678930</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2257,7 +2257,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/10.3758/s13423-018-1489-7' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Psychonomic Bulletin & Review</i></td>
-  <td><a href='https://dx.doi.org/10.3758/s13423-018-1489-7' target='_blank'>10.3758/s13423-018-1489-7</a></td>
+  <td><a href='https://doi.org/10.3758/s13423-018-1489-7' target='_blank'>10.3758/s13423-018-1489-7</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2281,7 +2281,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='https://reader.elsevier.com/reader/sd/84831579ABB7FB4A9E65124140616463E98CB1864D6ED867281EE20546205B0A1EB491B50D06682FBDF85B202232B1D2' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2018.02.009' target='_blank'>10.1016/j.cortex.2018.02.009</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2018.02.009' target='_blank'>10.1016/j.cortex.2018.02.009</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2300,7 +2300,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/http://www.tandfonline.com/doi/abs/10.1080/00224545.2017.1341374' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>The Journal of Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/00224545.2017.1341374' target='_blank'>10.1080/00224545.2017.1341374</a></td>
+  <td><a href='https://doi.org/10.1080/00224545.2017.1341374' target='_blank'>10.1080/00224545.2017.1341374</a></td>
   <td></td>
   <td>om</td>
   <td></td>
@@ -2332,7 +2332,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
     <a href='http://sci-hub.tw/https://www.sciencedirect.com/science/article/pii/S0022103117300860' target='_blank' class='sprite sprite-pdf-icon-medium'></a>
   </td>
   <td><i>Journal of Experimental Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.jesp.2017.07.002' target='_blank'>10.1016/j.jesp.2017.07.002</a></td>
+  <td><a href='https://doi.org/10.1016/j.jesp.2017.07.002' target='_blank'>10.1016/j.jesp.2017.07.002</a></td>
   <td>rs</td>
   <td></td>
   <td>prereg</td>

--- a/articles.html
+++ b/articles.html
@@ -489,7 +489,7 @@
 						  
 						  </td>
 						  <td ><i>Psychological Science</i></td>
-						  <td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018" class='doi-dimmed grey'>10.1177/0956797615571018</a></td>
+						  <td ><a target="_blank" href="https://doi.org/10.1177/0956797615571018" class='doi-dimmed grey'>10.1177/0956797615571018</a></td>
 						  <td>rs</td>
 						  <td>om</td>
 						  <td>prereg</td>
@@ -564,7 +564,7 @@
 							
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978" class='doi-dimmed grey'>10.1177/0956797615583978</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797615583978" class='doi-dimmed grey'>10.1177/0956797615583978</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -663,7 +663,7 @@
 							
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875" class='doi-dimmed grey'>10.1177/0956797616650875</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797616650875" class='doi-dimmed grey'>10.1177/0956797616650875</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -702,7 +702,7 @@
 							
 							</td>
 							<td ><i>Legal and Criminological Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x" class='doi-dimmed grey'>10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x" class='doi-dimmed grey'>10.1111/j.2044-8333.2011.02018.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -741,7 +741,7 @@
 							
 							</td>
 							<td ><i>Legal and Criminological Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2012.02047.x" class='doi-dimmed grey'>10.1111/j.2044-8333.2012.02047.x</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2012.02047.x" class='doi-dimmed grey'>10.1111/j.2044-8333.2012.02047.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -790,7 +790,7 @@
 								</td>
 								
 							<td ><i>Journal of Research in Personality</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001" class='doi-dimmed grey'>10.1016/j.jrp.2017.04.001</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001" class='doi-dimmed grey'>10.1016/j.jrp.2017.04.001</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -846,7 +846,7 @@
 								
 							</td>
 							<td ><i>Journal of Experimental Social Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2015.08.005" class='doi-dimmed grey'>10.1016/j.jesp.2015.08.005</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jesp.2015.08.005" class='doi-dimmed grey'>10.1016/j.jesp.2015.08.005</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -919,7 +919,7 @@
 							
 							</td>
 							<td ><i>Journal of Experimental Social Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2016.11.003" class='doi-dimmed grey'>10.1016/j.jesp.2016.11.003</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jesp.2016.11.003" class='doi-dimmed grey'>10.1016/j.jesp.2016.11.003</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -974,7 +974,7 @@
 							
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797613486983" class='doi-dimmed grey'>10.1177/0956797613486983</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797613486983" class='doi-dimmed grey'>10.1177/0956797613486983</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -1011,7 +1011,7 @@
 							
 							</td>
 							<td><i>Journal of Experimental Psychology: General</i></td>
-							<td ><a target="_blank" href="http://dx.doi.org/10.2139/ssrn.2958246" class='doi-dimmed grey'>10.2139/ssrn.2958246</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.2139/ssrn.2958246" class='doi-dimmed grey'>10.2139/ssrn.2958246</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -1044,7 +1044,7 @@
 							
 							</td>
 							<td ><i>European Journal of Personality</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1002/per.2137" class='doi-dimmed grey'>10.1002/per.2137</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1002/per.2137" class='doi-dimmed grey'>10.1002/per.2137</a></td>
 							<td></td>
 							<td>om</td>
 							<td></td>
@@ -1119,7 +1119,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-unavailable.png' class='shrunk-16'></a>  <a href='https://osf.io/69k2f/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797615595607' target='_blank' class='doi-dimmed grey'>10.1177/0956797615595607</a></td>
+  <td><a href='https://doi.org/10.1177/0956797615595607' target='_blank' class='doi-dimmed grey'>10.1177/0956797615595607</a></td>
   <td>rs</td>
   <td>om</td>
   <td></td>
@@ -1150,7 +1150,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/y8tf3/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797618760197' target='_blank' class='doi-dimmed grey'>10.1177/0956797618760197</a></td>
+  <td><a href='https://doi.org/10.1177/0956797618760197' target='_blank' class='doi-dimmed grey'>10.1177/0956797618760197</a></td>
   <td>rs</td>
   <td>om</td>
   <td></td>
@@ -1170,7 +1170,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/y74g6/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Attention, Perception, & Psychophysics</i></td>
-  <td><a href='https://dx.doi.org/10.3758/s13414-017-1304-y' target='_blank' class='doi-dimmed grey'>10.3758/s13414-017-1304-y</a></td>
+  <td><a href='https://doi.org/10.3758/s13414-017-1304-y' target='_blank' class='doi-dimmed grey'>10.3758/s13414-017-1304-y</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1190,7 +1190,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a>  <a href='https://codeocean.com/2017/11/29/who-gets-the-credit-quest-legislative-responsiveness-and-evaluations-of-members-parties-and-the-us-congress/code' target='_blank' title='Go to computational container'>
                        <img src='logos/sprite-icons/code-ocean.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Political Science Research and Methods</i></td>
-  <td><a href='https://dx.doi.org/10.1017/psrm.2015.83' target='_blank' class='doi-dimmed grey'>10.1017/psrm.2015.83</a></td>
+  <td><a href='https://doi.org/10.1017/psrm.2015.83' target='_blank' class='doi-dimmed grey'>10.1017/psrm.2015.83</a></td>
   <td></td>
   <td></td>
   <td></td>
@@ -1211,7 +1211,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a>  <a href='https://codeocean.com/2017/04/19/reanalysis-of-mouse-encode-comparative-gene-expression-data/code' target='_blank' title='Go to computational container'>
                        <img src='logos/sprite-icons/code-ocean.png' class='shrunk-16 transparent'></a> </td>
   <td><i>F1000Research</i></td>
-  <td><a href='https://dx.doi.org/10.12688/f1000research.6536.1' target='_blank' class='doi-dimmed grey'>10.12688/f1000research.6536.1</a></td>
+  <td><a href='https://doi.org/10.12688/f1000research.6536.1' target='_blank' class='doi-dimmed grey'>10.12688/f1000research.6536.1</a></td>
   <td></td>
   <td></td>
   <td></td>
@@ -1243,7 +1243,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/6v2c9/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797617719730' target='_blank' class='doi-dimmed grey'>10.1177/0956797617719730</a></td>
+  <td><a href='https://doi.org/10.1177/0956797617719730' target='_blank' class='doi-dimmed grey'>10.1177/0956797617719730</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1262,7 +1262,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Journal of Accounting Research</i></td>
-  <td><a href='https://dx.doi.org/10.1111/1475-679X.12198' target='_blank' class='doi-dimmed grey'>10.1111/1475-679X.12198</a></td>
+  <td><a href='https://doi.org/10.1111/1475-679X.12198' target='_blank' class='doi-dimmed grey'>10.1111/1475-679X.12198</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1292,7 +1292,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/krwxn/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797618761660' target='_blank' class='doi-dimmed grey'>10.1177/0956797618761660</a></td>
+  <td><a href='https://doi.org/10.1177/0956797618761660' target='_blank' class='doi-dimmed grey'>10.1177/0956797618761660</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1310,7 +1310,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2014.12.019' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2014.12.019</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2014.12.019' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2014.12.019</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1328,7 +1328,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/7HCESJ' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.004' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.03.004</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.004' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.03.004</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1346,7 +1346,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2015.03.010' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2015.03.010</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2015.03.010' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2015.03.010</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1364,7 +1364,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.01.006' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.01.006</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.01.006' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.01.006</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1384,7 +1384,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://data.mendeley.com/datasets/4676n2pdrf/3' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.020' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.03.020</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.020' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.03.020</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1402,7 +1402,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.019' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.03.019</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.019' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2016.03.019</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1420,7 +1420,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2018.01.001' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2018.01.001</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2018.01.001' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2018.01.001</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1442,7 +1442,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/rq7he/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.160431' target='_blank' class='doi-dimmed grey'>10.1098/rsos.160431</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.160431' target='_blank' class='doi-dimmed grey'>10.1098/rsos.160431</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1461,7 +1461,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='https://datadryad.org/resource/doi:10.5061/dryad.fv5mn' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.171172' target='_blank' class='doi-dimmed grey'>10.1098/rsos.171172</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.171172' target='_blank' class='doi-dimmed grey'>10.1098/rsos.171172</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1481,7 +1481,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/cx5eh/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.160935' target='_blank' class='doi-dimmed grey'>10.1098/rsos.160935</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.160935' target='_blank' class='doi-dimmed grey'>10.1098/rsos.160935</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1502,7 +1502,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/v2kws/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.171678' target='_blank' class='doi-dimmed grey'>10.1098/rsos.171678</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.171678' target='_blank' class='doi-dimmed grey'>10.1098/rsos.171678</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1523,7 +1523,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://zenodo.org/record/1006730#.WwO9DIiFNEY' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.170543' target='_blank' class='doi-dimmed grey'>10.1098/rsos.170543</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.170543' target='_blank' class='doi-dimmed grey'>10.1098/rsos.170543</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1541,7 +1541,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414016633228' target='_blank' class='doi-dimmed grey'>10.1177/0010414016633228</a></td>
+  <td><a href='https://doi.org/10.1177/0010414016633228' target='_blank' class='doi-dimmed grey'>10.1177/0010414016633228</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1559,7 +1559,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414015626436' target='_blank' class='doi-dimmed grey'>10.1177/0010414015626436</a></td>
+  <td><a href='https://doi.org/10.1177/0010414015626436' target='_blank' class='doi-dimmed grey'>10.1177/0010414015626436</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1577,7 +1577,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414015621072' target='_blank' class='doi-dimmed grey'>10.1177/0010414015621072</a></td>
+  <td><a href='https://doi.org/10.1177/0010414015621072' target='_blank' class='doi-dimmed grey'>10.1177/0010414015621072</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1598,7 +1598,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/8l4ea/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.26030.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.26030.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.26030.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.26030.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1619,7 +1619,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/hcqqy/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.25306.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.25306.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.25306.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.25306.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1640,7 +1640,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/pnvtd/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.21253.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.21253.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.21253.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.21253.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1661,7 +1661,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/xu1g2/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.17584.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.17584.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.17584.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.17584.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1682,7 +1682,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/hxrmm/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.17044.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.17044.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.17044.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.17044.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1703,7 +1703,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/y4q5r/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.18173.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.18173.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.18173.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.18173.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1725,7 +1725,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/jvpnw/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.21634.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.21634.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.21634.001' target='_blank' class='doi-dimmed grey'>10.7554/eLife.21634.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1747,7 +1747,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/nbryi/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.29747' target='_blank' class='doi-dimmed grey'>10.7554/eLife.29747</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.29747' target='_blank' class='doi-dimmed grey'>10.7554/eLife.29747</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1769,7 +1769,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/mokeb/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.30274' target='_blank' class='doi-dimmed grey'>10.7554/eLife.30274</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.30274' target='_blank' class='doi-dimmed grey'>10.7554/eLife.30274</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1788,7 +1788,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000286' target='_blank' class='doi-dimmed grey'>10.1027/1618-3169/a000286</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000286' target='_blank' class='doi-dimmed grey'>10.1027/1618-3169/a000286</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1806,7 +1806,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000364' target='_blank' class='doi-dimmed grey'>10.1027/1618-3169/a000364</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000364' target='_blank' class='doi-dimmed grey'>10.1027/1618-3169/a000364</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1825,7 +1825,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000372' target='_blank' class='doi-dimmed grey'>10.1027/1618-3169/a000372</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000372' target='_blank' class='doi-dimmed grey'>10.1027/1618-3169/a000372</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1846,7 +1846,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/xpb7t/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Journal of Media Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-1105/a000210' target='_blank' class='doi-dimmed grey'>10.1027/1864-1105/a000210</a></td>
+  <td><a href='https://doi.org/10.1027/1864-1105/a000210' target='_blank' class='doi-dimmed grey'>10.1027/1864-1105/a000210</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1867,7 +1867,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/7cjd6/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Journal of Media Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-1105/a000209' target='_blank' class='doi-dimmed grey'>10.1027/1864-1105/a000209</a></td>
+  <td><a href='https://doi.org/10.1027/1864-1105/a000209' target='_blank' class='doi-dimmed grey'>10.1027/1864-1105/a000209</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1917,7 +1917,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/8p5sr/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616649604' target='_blank' class='doi-dimmed grey'>10.1177/0956797616649604</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616649604' target='_blank' class='doi-dimmed grey'>10.1177/0956797616649604</a></td>
   <td>rs</td>
   <td></td>
   <td>prereg</td>
@@ -1949,7 +1949,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/g3sca/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797614553121' target='_blank' class='doi-dimmed grey'>10.1177/0956797614553121</a></td>
+  <td><a href='https://doi.org/10.1177/0956797614553121' target='_blank' class='doi-dimmed grey'>10.1177/0956797614553121</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1979,7 +1979,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616638307' target='_blank' class='doi-dimmed grey'>10.1177/0956797616638307</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616638307' target='_blank' class='doi-dimmed grey'>10.1177/0956797616638307</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2008,7 +2008,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/c2gaf/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797615572909' target='_blank' class='doi-dimmed grey'>10.1177/0956797615572909</a></td>
+  <td><a href='https://doi.org/10.1177/0956797615572909' target='_blank' class='doi-dimmed grey'>10.1177/0956797615572909</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2029,7 +2029,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/e6cr3/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.00875' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2014.00875</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.00875' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2014.00875</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2050,7 +2050,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/wxigz/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00335' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2015.00335</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00335' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2015.00335</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2072,7 +2072,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/8zdqt/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.00786' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2014.00786</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.00786' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2014.00786</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2094,7 +2094,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/9n62e/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.01035' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2014.01035</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.01035' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2014.01035</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2116,7 +2116,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/j8w4i/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00672' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2015.00672</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00672' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2015.00672</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2138,7 +2138,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/uszvx/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00494' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2015.00494</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00494' target='_blank' class='doi-dimmed grey'>10.3389/fpsyg.2015.00494</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2157,7 +2157,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/g85ep/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2017.1341178' target='_blank' class='doi-dimmed grey'>10.1080/23743603.2017.1341178</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2017.1341178' target='_blank' class='doi-dimmed grey'>10.1080/23743603.2017.1341178</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2178,7 +2178,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/um26s/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2017.1341186' target='_blank' class='doi-dimmed grey'>10.1080/23743603.2017.1341186</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2017.1341186' target='_blank' class='doi-dimmed grey'>10.1080/23743603.2017.1341186</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2197,7 +2197,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                     <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2016.1248081' target='_blank' class='doi-dimmed grey'>10.1080/23743603.2016.1248081</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2016.1248081' target='_blank' class='doi-dimmed grey'>10.1080/23743603.2016.1248081</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2218,7 +2218,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='http://www.openscienceframework.org/project/3cmz4/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000189' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000189</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000189' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000189</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2240,7 +2240,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/bggzq/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000191' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000191</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000191' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000191</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2261,7 +2261,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='http://www.openscienceframework.org/project/fsadm/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000190' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000190</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000190' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000190</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2282,7 +2282,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a title='Open data information is not available'>
                 <img src='logos/sprite-icons/data-unavailable.png' class='shrunk-16'></a> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000184' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000184</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000184' target='_blank' class='doi-dimmed grey'>10.1027/1864-9335/a000184</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2303,7 +2303,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/hr7vx/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Journal of Research in Personality</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.jrp.2017.10.005' target='_blank' class='doi-dimmed grey'>10.1016/j.jrp.2017.10.005</a></td>
+  <td><a href='https://doi.org/10.1016/j.jrp.2017.10.005' target='_blank' class='doi-dimmed grey'>10.1016/j.jrp.2017.10.005</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2323,7 +2323,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-plus-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/cm2sj/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Cognition and Emotion</i></td>
-  <td><a href='https://dx.doi.org/10.1080/02699931.2018.1429389' target='_blank' class='doi-dimmed grey'>10.1080/02699931.2018.1429389</a></td>
+  <td><a href='https://doi.org/10.1080/02699931.2018.1429389' target='_blank' class='doi-dimmed grey'>10.1080/02699931.2018.1429389</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2341,7 +2341,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/wdvpz/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Perception</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0301006617720831' target='_blank' class='doi-dimmed grey'>10.1177/0301006617720831</a></td>
+  <td><a href='https://doi.org/10.1177/0301006617720831' target='_blank' class='doi-dimmed grey'>10.1177/0301006617720831</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2361,7 +2361,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/a8g32/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>PeerJ</i></td>
-  <td><a href='https://dx.doi.org/10.7717/peerj.837' target='_blank' class='doi-dimmed grey'>10.7717/peerj.837</a></td>
+  <td><a href='https://doi.org/10.7717/peerj.837' target='_blank' class='doi-dimmed grey'>10.7717/peerj.837</a></td>
   <td></td>
   <td>om</td>
   <td></td>
@@ -2390,7 +2390,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                            <img src='logos/sprite-icons/preregistered-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/rh2dq/' target='_blank' title='Go to data files'>
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616678930' target='_blank' class='doi-dimmed grey'>10.1177/0956797616678930</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616678930' target='_blank' class='doi-dimmed grey'>10.1177/0956797616678930</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2425,7 +2425,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/b94yx/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Psychonomic Bulletin & Review</i></td>
-  <td><a href='https://dx.doi.org/10.3758/s13423-018-1489-7' target='_blank' class='doi-dimmed grey'>10.3758/s13423-018-1489-7</a></td>
+  <td><a href='https://doi.org/10.3758/s13423-018-1489-7' target='_blank' class='doi-dimmed grey'>10.3758/s13423-018-1489-7</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2446,7 +2446,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://data.mendeley.com/datasets/b5grw3pz3r/1' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2018.02.009' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2018.02.009</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2018.02.009' target='_blank' class='doi-dimmed grey'>10.1016/j.cortex.2018.02.009</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2464,7 +2464,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/v72ca/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>The Journal of Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/00224545.2017.1341374' target='_blank' class='doi-dimmed grey'>10.1080/00224545.2017.1341374</a></td>
+  <td><a href='https://doi.org/10.1080/00224545.2017.1341374' target='_blank' class='doi-dimmed grey'>10.1080/00224545.2017.1341374</a></td>
   <td></td>
   <td>om</td>
   <td></td>
@@ -2495,7 +2495,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/u6xwr/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Journal of Experimental Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.jesp.2017.07.002' target='_blank' class='doi-dimmed grey'>10.1016/j.jesp.2017.07.002</a></td>
+  <td><a href='https://doi.org/10.1016/j.jesp.2017.07.002' target='_blank' class='doi-dimmed grey'>10.1016/j.jesp.2017.07.002</a></td>
   <td>rs</td>
   <td></td>
   <td>prereg</td>
@@ -2590,7 +2590,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/sgjpy/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Scientific Data</i></td>
-  <td><a href='https://dx.doi.org/10.1038/sdata.2016.129' target='_blank' class='doi-dimmed grey'>10.1038/sdata.2016.129</a></td>
+  <td><a href='https://doi.org/10.1038/sdata.2016.129' target='_blank' class='doi-dimmed grey'>10.1038/sdata.2016.129</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2622,7 +2622,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/nqc8t/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Scientific Data</i></td>
-  <td><a href='https://dx.doi.org/10.1038/sdata.2016.120' target='_blank' class='doi-dimmed grey'>10.1038/sdata.2016.120</a></td>
+  <td><a href='https://doi.org/10.1038/sdata.2016.120' target='_blank' class='doi-dimmed grey'>10.1038/sdata.2016.120</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2641,7 +2641,7 @@ Basic 4 (at submission)</a> <img src='logos/sprite-icons/disclosure-available.pn
                        <img src='logos/sprite-icons/data-available.png' class='shrunk-16 transparent'></a>  <a href='https://osf.io/q46ye/' target='_blank' title='Go to reproducible code files'>
                        <img src='logos/sprite-icons/code.png' class='shrunk-16 code-icon'></a> </td>
   <td><i>Evolutionary Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1177/1474704918776748' target='_blank' class='doi-dimmed grey'>10.1177/1474704918776748</a></td>
+  <td><a href='https://doi.org/10.1177/1474704918776748' target='_blank' class='doi-dimmed grey'>10.1177/1474704918776748</a></td>
   <td></td>
   <td>om</td>
   <td></td>

--- a/curated/RR-articles[from-Hardwicke-et-al].csv
+++ b/curated/RR-articles[from-Hardwicke-et-al].csv
@@ -1,11 +1,11 @@
 journal_full,id,protocolMadeAvailable,reasonForNoShare,public,duplicate,protocolLinkProvided,registered,timingsAvailable,Date of in principle acceptance,Have the authors submitted a full paper,Date of submission of full paper,Has the paper been published,Date of publication of full paper,linkToPaper,numberOfRegisteredStudies,replication,design,identifiesAsRR,editorialConfirmsRR
 International Journal of Psychophysiology,IJP_1,yes,NA,yes,no,https://osf.io/tn7j9/,OSF timestamp only,yes,5/19/17,no,NA,no,NA,NA,NA,NA,NA,NA,NA
-Cortex,COR_1,yes,NA,no,no,NA,NA,yes,11/26/13,yes,8/19/14,yes,2/13/15,http://dx.doi.org/10.1016/j.cortex.2014.12.019,2,no,laboratoryCrossover,RR,NA
-Cortex,COR_2,yes,NA,no,no,NA,NA,yes,2002-02-13,yes,2009-01-15,yes,3/31/16,http://dx.doi.org/10.1016/j.cortex.2016.03.004,1,no,laboratoryCrossover,RR,NA
-Cortex,COR_3,yes,NA,no,no,NA,NA,yes,2005-07-14,yes,2002-03-15,yes,4/17/15,http://dx.doi.org/10.1016/j.cortex.2015.03.010,1,no,laboratoryCrossover,RR,NA
-Cortex,COR_4,yes,NA,no,no,NA,NA,yes,10/21/14,yes,2005-05-15,yes,2002-06-16,http://dx.doi.org/10.1016/j.cortex.2016.01.006,1,no,laboratoryCrossover,RR,NA
-Cortex,COR_5,yes,NA,no,no,NA,NA,yes,2009-02-14,yes,9/29/15,yes,2004-06-16,http://dx.doi.org/10.1016/j.cortex.2016.03.020,1,no,laboratoryCrossover,RR,NA
-Cortex,COR_6,yes,NA,no,no,NA,NA,yes,1/30/15,yes,1/20/16,yes,4/15/16,http://dx.doi.org/10.1016/j.cortex.2016.03.019,1,no,laboratoryCrossover,RR,NA
+Cortex,COR_1,yes,NA,no,no,NA,NA,yes,11/26/13,yes,8/19/14,yes,2/13/15,https://doi.org/10.1016/j.cortex.2014.12.019,2,no,laboratoryCrossover,RR,NA
+Cortex,COR_2,yes,NA,no,no,NA,NA,yes,2002-02-13,yes,2009-01-15,yes,3/31/16,https://doi.org/10.1016/j.cortex.2016.03.004,1,no,laboratoryCrossover,RR,NA
+Cortex,COR_3,yes,NA,no,no,NA,NA,yes,2005-07-14,yes,2002-03-15,yes,4/17/15,https://doi.org/10.1016/j.cortex.2015.03.010,1,no,laboratoryCrossover,RR,NA
+Cortex,COR_4,yes,NA,no,no,NA,NA,yes,10/21/14,yes,2005-05-15,yes,2002-06-16,https://doi.org/10.1016/j.cortex.2016.01.006,1,no,laboratoryCrossover,RR,NA
+Cortex,COR_5,yes,NA,no,no,NA,NA,yes,2009-02-14,yes,9/29/15,yes,2004-06-16,https://doi.org/10.1016/j.cortex.2016.03.020,1,no,laboratoryCrossover,RR,NA
+Cortex,COR_6,yes,NA,no,no,NA,NA,yes,1/30/15,yes,1/20/16,yes,4/15/16,https://doi.org/10.1016/j.cortex.2016.03.019,1,no,laboratoryCrossover,RR,NA
 Cortex,COR_7,no,authorConfidentiality,no,no,NA,NA,yes,6/18/15,yes,6/28/17,yes,1/31/18,https://doi.org/10.1016/j.cortex.2018.01.001,2,no,laboratoryCrossover,RR,NA
 Cortex,COR_8,no,authorConfidentiality,no,no,NA,NA,yes,9/14/16,no,NA,no,NA,NA,NA,NA,NA,NA,NA
 Cortex,COR_9,no,authorConfidentiality,no,no,NA,NA,yes,1/24/17,no,NA,no,NA,NA,NA,NA,NA,NA,NA
@@ -17,7 +17,7 @@ Cortex,COR_14,no,authorConfidentiality,no,no,NA,NA,yes,2/24/17,no,NA,no,NA,NA,NA
 Cortex,COR_15,no,authorConfidentiality,no,no,NA,NA,yes,2006-02-17,no,NA,no,NA,NA,NA,NA,NA,NA,NA
 Cognitive Research: Principles and Implications,CRPI_1,yes,NA,yes,no,https://osf.io/hzd5v/,OSF timestamp only,no,?,no,NA,no,NA,NA,NA,NA,NA,NA,NA
 European Journal of Neuroscience,EJN_1,no,authorConfidentiality,no,no,NA,NA,yes,4/25/17,no,NA,no,NA,NA,NA,NA,NA,NA,NA
-Royal Society Open Science,RSOS_1,yes,NA,yes,yes,https://osf.io/pzf2e/,yes,yes,2007-03-16,yes,2009-08-16,yes,11/23/16,https://dx.doi.org/10.1098/rsos.160431,2,yes,laboratoryIndependentGroups,RR,NA
+Royal Society Open Science,RSOS_1,yes,NA,yes,yes,https://osf.io/pzf2e/,yes,yes,2007-03-16,yes,2009-08-16,yes,11/23/16,https://doi.org/10.1098/rsos.160431,2,yes,laboratoryIndependentGroups,RR,NA
 Royal Society Open Science,RSOS_2,yes,authorConfidentiality,no,no,NA,NA,yes,2012-12-16,yes,NA,yes,2010-04-17, https://doi.org/10.1098/rsos.171172 ,1,no,observational,RR,NA
 Royal Society Open Science,RSOS_3,yes,authorConfidentiality,no,no,NA,NA,yes,3/14/17,yes,NA,yes,9/20/17,https://doi.org/10.1098/rsos.160935,1,no,laboratoryIndependentGroups,RR,NA
 Royal Society Open Science,RSOS_4,yes,authorConfidentiality,yes,no,https://osf.io/qbp7h/,OSF timestamp only,yes,2/22/17,yes,7/19/17,yes,2/21/18,https://doi.org/10.1098/rsos.171678,1,no,laboratoryCrossover,RR,NA
@@ -124,7 +124,7 @@ Social Psychology,SP_11,yes,NA,yes,no,https://osf.io/6wxgf/,yes,no,?,yes,?,yes,2
 Social Psychology,SP_12,yes,NA,yes,no,http://osf.io/s92i4/,yes,no,?,yes,?,yes,2001-01-14,https://doi.org/10.1027/1864-9335/a000180,1,yes,laboratoryCrossover,P,https://doi.org/10.1027/1864-9335/a000203
 Social Psychology,SP_13,yes,NA,yes,no,https://osf.io/vyacr/,yes,no,?,yes,?,yes,2001-01-14,https://doi.org/10.1027/1864-9335/a000188,4,yes,laboratoryIndependentGroups,P,https://doi.org/10.1027/1864-9335/a000204
 Social Psychology,SP_14,yes,NA,yes,no,http://osf.io/b9pkj/,yes,no,?,yes,?,yes,2001-01-14,https://doi.org/10.1027/1864-9335/a000193,1,yes,laboratoryIndependentGroups,P,https://doi.org/10.1027/1864-9335/a000204
-Social Psychology,SP_15,yes,NA,yes,no,http://osf.io/r6idy/,yes,no,?,yes,?,yes,2001-01-14,http://dx.doi.org/10.1027/1864-9335/a000179,1,yes,laboratoryIndependentGroups,P,https://doi.org/10.1027/1864-9335/a000205
+Social Psychology,SP_15,yes,NA,yes,no,http://osf.io/r6idy/,yes,no,?,yes,?,yes,2001-01-14,https://doi.org/10.1027/1864-9335/a000179,1,yes,laboratoryIndependentGroups,P,https://doi.org/10.1027/1864-9335/a000205
 Perspectives on Psychological Science,PPS_1,yes,NA,yes,no,https://osf.io/ybeur/,yes,no,?,yes,?,yes,9/17/14,https://doi.org/10.1177/1745691614545653,2,yes,laboratoryIndependentGroups,RR,NA
 Perspectives on Psychological Science,PPS_2,yes,NA,yes,no,https://osf.io/d3mw4/,yes,no,?,yes,?,yes,7/27/16,https://doi.org/10.1177/1745691615605826,1,yes,laboratoryIndependentGroups,RR,NA
 Perspectives on Psychological Science,PPS_3,yes,NA,yes,no,https://osf.io/jymhe/,yes,no,?,yes,?,yes,7/29/16,https://doi.org/10.1177/1745691616652873,1,yes,laboratoryIndependentGroups,RR,NA

--- a/curated/generate-HTML-open-articles-v1[badges-w-authors].R
+++ b/curated/generate-HTML-open-articles-v1[badges-w-authors].R
@@ -141,7 +141,7 @@ RR.HTML <- function(rr, prereg.URL) {
 }
 DOI.HTML <- function(DOI) {
   if(toString(DOI) != "NA") {
-    return(HTML(paste0("<a href='https://dx.doi.org/", DOI,"' target='_blank'>",DOI,"</a>")))} #still not trimming correctly but link still works
+    return(HTML(paste0("<a href='https://doi.org/", DOI,"' target='_blank'>",DOI,"</a>")))} #still not trimming correctly but link still works
 }
 journal.name.HTML <- function(journal.name) {
   return(HTML(paste0("<i>",journal.name,"</i>")))

--- a/curated/generate-HTML-open-articles.R
+++ b/curated/generate-HTML-open-articles.R
@@ -146,7 +146,7 @@ RR.label <- function(rr, prereg.URL) {
 }
 DOI.HTML <- function(DOI) {
   if(toString(DOI) != "NA") {
-    return(HTML(paste0("<a href='https://dx.doi.org/", DOI,"' target='_blank' class='doi-dimmed grey'>",DOI,"</a>")))} #still not trimming correctly but link still works
+    return(HTML(paste0("<a href='https://doi.org/", DOI,"' target='_blank' class='doi-dimmed grey'>",DOI,"</a>")))} #still not trimming correctly but link still works
 }
 journal.name.HTML <- function(journal.name) {
   return(HTML(paste0("<i>",journal.name,"</i>")))

--- a/index-popupViewPDF-test.html
+++ b/index-popupViewPDF-test.html
@@ -23655,7 +23655,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
 						  <td style="vertical-align:top;"><a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Justifications Shape Ethical Blind Spots</td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23739,7 +23739,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23777,7 +23777,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Implicit Social Biases in People With Autism</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23869,7 +23869,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23905,7 +23905,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
 							<td style="vertical-align:top;"><a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23928,7 +23928,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">

--- a/index.html
+++ b/index.html
@@ -23554,7 +23554,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 						  <td style="vertical-align:top;"><a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Justifications Shape Ethical Blind Spots</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						  <td>rs</td>
 						  <td>om</td>
 						  <td>prereg</td>
@@ -23625,7 +23625,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -23661,7 +23661,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Implicit Social Biases in People With Autism</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -23756,7 +23756,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -23790,7 +23790,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -23834,7 +23834,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href=' https://static1.squarespace.com/static/594641bbe3df28301b1a0493/t/5970b5c8f5e2311272d3b4f0/1500558794416/2017+%28in+press%29_Campbell+et+al_JRP_Replication+of+Murray+et+al+2002.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Self-esteem, relationship threat, and dependency regulation: Independent replication of Murray, Rose, Bellavia, Holmes, and Kusche (2002) Study 3 <span class="label label-info-purple"><a href="https://psyarxiv.com/5suda/" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td style="vertical-align:top;"><i>Journal of Research in Personality</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -23862,7 +23862,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='http://journals.sagepub.com/doi/pdf/10.1177/0956797618760197' target='_blank' class='sprite sprite-pdf-icon-medium'></a> No Compelling Evidence That Preferences for Facial Masculinity Track Changes in Women’s Hormonal Status <span class="label label-info-purple"><a href="https://www.biorxiv.org/content/early/2017/12/29/136549.full.pdf+html" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797618760197">10.1177/0956797618760197</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797618760197">10.1177/0956797618760197</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -23880,7 +23880,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://link.springer.com/content/pdf/10.3758%2Fs13414-017-1304-y.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> A test of the diffusion model explanation for the worst performance rule using preregistration and blinding <span class="label label-info-red"><a href="https://osf.io/we65f/" target="_blank" class="black">Registered Report</a></span></td>
 							<td style="vertical-align:top;"><i>Attention, Perception, & Psychophysics</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.3758/s13414-017-1304-y">10.3758/s13414-017-1304-y</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.3758/s13414-017-1304-y">10.3758/s13414-017-1304-y</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -23931,7 +23931,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='http://www.scottconnors.ca/uploads/4/7/4/6/47460837/connors_khamitov_moroz_campbell_and_henderson__2016__jesp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Time, money, and happiness: Does putting a price on time affect our ability to smell the roses? </td>
 							<td style="vertical-align:top;"><i>Journal of Experimental Social Psychology</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2015.08.005">10.1016/j.jesp.2015.08.005</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jesp.2015.08.005">10.1016/j.jesp.2015.08.005</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -24000,7 +24000,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://s3.amazonaws.com/academia.edu.documents/50411489/Does_exposure_to_erotica_reduce_attraction_and_love_for_romantic_partners.pdf?AWSAccessKeyId=AKIAIWOWYYGZ2Y53UL3A&Expires=1525594020&Signature=mi1N1Tez8jZK6UNvrFEZLHuIAPU%3D&response-content-disposition=inline%3B%20filename%3DDoes_exposure_to_erotica_reduce_attracti.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Does exposure to erotica reduce attraction and love for romantic partners in men? Independent replications of Kenrick, Gutierres, and Goldberg (1989) Study 2 </td>
 							<td style="vertical-align:top;"><i>Journal of Experimental Social Psychology</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2016.11.003">10.1016/j.jesp.2016.11.003</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jesp.2016.11.003">10.1016/j.jesp.2016.11.003</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -24051,7 +24051,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='http://etiennelebel.com/documents/l&c(2013,psci).pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Heightened Sensitivity to Temperature Cues in Individuals With High Anxious Attachment: Real or Elusive Phenomenon? </td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797613486983">10.1177/0956797613486983</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797613486983">10.1177/0956797613486983</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -24084,7 +24084,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Gordon_Pennycook/publication/317069544_Implausibility_and_illusory_truth_Prior_exposure_increases_perceived_accuracy_of_fake_news_but_has_no_effect_on_entirely_implausible_statements/links/5a1dc207458515a4c3d1ad4a/Implausibility-and-illusory-truth-Prior-exposure-increases-perceived-accuracy-of-fake-news-but-has-no-effect-on-entirely-implausible-statements.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Prior exposure increases perceived accuracy of fake news <span class="label label-info-purple"><a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2958246" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td style="vertical-align:top;"><i>Journal of Experimental Psychology: General</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="http://dx.doi.org/10.2139/ssrn.2958246">10.2139/ssrn.2958246</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.2139/ssrn.2958246">10.2139/ssrn.2958246</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -24112,7 +24112,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 							<td></td>
 							<td>om</td>
 							<td></td>

--- a/old-stuff/articles_backup[2018-05-23].html
+++ b/old-stuff/articles_backup[2018-05-23].html
@@ -230,7 +230,7 @@
 							</td>
 						  <td style="vertical-align:top;"><a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Justifications Shape Ethical Blind Spots</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						  <td>rs</td>
 						  <td>om</td>
 						  <td>prereg</td>
@@ -301,7 +301,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -337,7 +337,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Implicit Social Biases in People With Autism</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -432,7 +432,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -466,7 +466,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -510,7 +510,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href=' https://static1.squarespace.com/static/594641bbe3df28301b1a0493/t/5970b5c8f5e2311272d3b4f0/1500558794416/2017+%28in+press%29_Campbell+et+al_JRP_Replication+of+Murray+et+al+2002.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Self-esteem, relationship threat, and dependency regulation: Independent replication of Murray, Rose, Bellavia, Holmes, and Kusche (2002) Study 3 <span class="label label-info-purple"><a href="https://psyarxiv.com/5suda/" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td style="vertical-align:top;"><i>Journal of Research in Personality</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -538,7 +538,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='http://journals.sagepub.com/doi/pdf/10.1177/0956797618760197' target='_blank' class='sprite sprite-pdf-icon-medium'></a> No Compelling Evidence That Preferences for Facial Masculinity Track Changes in Women’s Hormonal Status <span class="label label-info-purple"><a href="https://www.biorxiv.org/content/early/2017/12/29/136549.full.pdf+html" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797618760197">10.1177/0956797618760197</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797618760197">10.1177/0956797618760197</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -556,7 +556,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='https://link.springer.com/content/pdf/10.3758%2Fs13414-017-1304-y.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> A test of the diffusion model explanation for the worst performance rule using preregistration and blinding <span class="label label-info-red"><a href="https://osf.io/we65f/" target="_blank" class="black" title="Go to Registered Report preregistered study protocol">Registered Report</a></span></td>
 							<td style="vertical-align:top;"><i>Attention, Perception, & Psychophysics</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.3758/s13414-017-1304-y">10.3758/s13414-017-1304-y</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.3758/s13414-017-1304-y">10.3758/s13414-017-1304-y</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -607,7 +607,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='http://www.scottconnors.ca/uploads/4/7/4/6/47460837/connors_khamitov_moroz_campbell_and_henderson__2016__jesp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Time, money, and happiness: Does putting a price on time affect our ability to smell the roses? </td>
 							<td style="vertical-align:top;"><i>Journal of Experimental Social Psychology</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2015.08.005">10.1016/j.jesp.2015.08.005</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jesp.2015.08.005">10.1016/j.jesp.2015.08.005</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -676,7 +676,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Rhonda_Balzarini/publication/310488568_Does_exposure_to_erotica_reduce_attraction_and_love_for_romantic_partners_in_men_Independent_replications_of_Kenrick_Gutierres_and_Goldberg_1989_study_2/links/59cfdd434585150177ee21fd/Does-exposure-to-erotica-reduce-attraction-and-love-for-romantic-partners-in-men-Independent-replications-of-Kenrick-Gutierres-and-Goldberg-1989-study-2.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Does exposure to erotica reduce attraction and love for romantic partners in men? Independent replications of Kenrick, Gutierres, and Goldberg (1989) Study 2 </td>
 							<td style="vertical-align:top;"><i>Journal of Experimental Social Psychology</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2016.11.003">10.1016/j.jesp.2016.11.003</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jesp.2016.11.003">10.1016/j.jesp.2016.11.003</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -727,7 +727,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='http://etiennelebel.com/documents/l&c(2013,psci).pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Heightened Sensitivity to Temperature Cues in Individuals With High Anxious Attachment: Real or Elusive Phenomenon? </td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797613486983">10.1177/0956797613486983</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797613486983">10.1177/0956797613486983</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -760,7 +760,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Gordon_Pennycook/publication/317069544_Implausibility_and_illusory_truth_Prior_exposure_increases_perceived_accuracy_of_fake_news_but_has_no_effect_on_entirely_implausible_statements/links/5a1dc207458515a4c3d1ad4a/Implausibility-and-illusory-truth-Prior-exposure-increases-perceived-accuracy-of-fake-news-but-has-no-effect-on-entirely-implausible-statements.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Prior exposure increases perceived accuracy of fake news <span class="label label-info-purple"><a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2958246" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td style="vertical-align:top;"><i>Journal of Experimental Psychology: General</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="http://dx.doi.org/10.2139/ssrn.2958246">10.2139/ssrn.2958246</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.2139/ssrn.2958246">10.2139/ssrn.2958246</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -788,7 +788,7 @@
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 							<td></td>
 							<td>om</td>
 							<td></td>

--- a/old-stuff/articles_backup[2018-06-09].html
+++ b/old-stuff/articles_backup[2018-06-09].html
@@ -616,7 +616,7 @@
 						  
 						  </td>
 						  <td ><i>Psychological Science</i></td>
-						  <td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018" class="doi-dimmed">10.1177/0956797615571018</a></td>
+						  <td ><a target="_blank" href="https://doi.org/10.1177/0956797615571018" class="doi-dimmed">10.1177/0956797615571018</a></td>
 						  <td>rs</td>
 						  <td>om</td>
 						  <td>prereg</td>
@@ -691,7 +691,7 @@
 							
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978" class="doi-dimmed">10.1177/0956797615583978</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797615583978" class="doi-dimmed">10.1177/0956797615583978</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -732,7 +732,7 @@
 								</div>
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607" class="doi-dimmed">10.1177/0956797615595607</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797615595607" class="doi-dimmed">10.1177/0956797615595607</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -832,7 +832,7 @@
 							
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875" class="doi-dimmed">10.1177/0956797616650875</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797616650875" class="doi-dimmed">10.1177/0956797616650875</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -872,7 +872,7 @@
 							
 							</td>
 							<td ><i>Legal and Criminological Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x" class="doi-dimmed">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x" class="doi-dimmed">10.1111/j.2044-8333.2011.02018.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -912,7 +912,7 @@
 							
 							</td>
 							<td ><i>Legal and Criminological Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2012.02047.x" class="doi-dimmed">10.1111/j.2044-8333.2012.02047.x</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2012.02047.x" class="doi-dimmed">10.1111/j.2044-8333.2012.02047.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -962,7 +962,7 @@
 								<span class="label label-info-purple"><a href="https://psyarxiv.com/5suda/" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 								
 							<td ><i>Journal of Research in Personality</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001" class="doi-dimmed">10.1016/j.jrp.2017.04.001</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001" class="doi-dimmed">10.1016/j.jrp.2017.04.001</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -996,7 +996,7 @@
 							<span class="label label-info-purple"><a href="https://www.biorxiv.org/content/early/2017/12/29/136549.full.pdf+html" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span>
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797618760197" class="doi-dimmed">10.1177/0956797618760197</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797618760197" class="doi-dimmed">10.1177/0956797618760197</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -1020,7 +1020,7 @@
 								<span class="label label-info-red"><a href="https://osf.io/we65f/" target="_blank" class="black" title="Go to Registered Report preregistered study protocol">Registered Report</a></span>
 							</td>
 							<td ><i>Attention, Perception, & Psychophysics</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.3758/s13414-017-1304-y" class="doi-dimmed">10.3758/s13414-017-1304-y</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.3758/s13414-017-1304-y" class="doi-dimmed">10.3758/s13414-017-1304-y</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -1076,7 +1076,7 @@
 								
 							</td>
 							<td ><i>Journal of Experimental Social Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2015.08.005" class="doi-dimmed">10.1016/j.jesp.2015.08.005</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jesp.2015.08.005" class="doi-dimmed">10.1016/j.jesp.2015.08.005</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -1150,7 +1150,7 @@
 							
 							</td>
 							<td ><i>Journal of Experimental Social Psychology</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1016/j.jesp.2016.11.003" class="doi-dimmed">10.1016/j.jesp.2016.11.003</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1016/j.jesp.2016.11.003" class="doi-dimmed">10.1016/j.jesp.2016.11.003</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -1206,7 +1206,7 @@
 							
 							</td>
 							<td ><i>Psychological Science</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1177/0956797613486983" class="doi-dimmed">10.1177/0956797613486983</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1177/0956797613486983" class="doi-dimmed">10.1177/0956797613486983</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -1244,7 +1244,7 @@
 							
 							</td>
 							<td><i>Journal of Experimental Psychology: General</i></td>
-							<td ><a target="_blank" href="http://dx.doi.org/10.2139/ssrn.2958246" class="doi-dimmed">10.2139/ssrn.2958246</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.2139/ssrn.2958246" class="doi-dimmed">10.2139/ssrn.2958246</a></td>
 							<td></td>
 							<td>om</td>
 							<td>prereg</td>
@@ -1278,7 +1278,7 @@
 							
 							</td>
 							<td ><i>European Journal of Personality</i></td>
-							<td ><a target="_blank" href="https://dx.doi.org/10.1002/per.2137" class="doi-dimmed">10.1002/per.2137</a></td>
+							<td ><a target="_blank" href="https://doi.org/10.1002/per.2137" class="doi-dimmed">10.1002/per.2137</a></td>
 							<td></td>
 							<td>om</td>
 							<td></td>
@@ -1404,7 +1404,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to data files'></a> <span class='label label-info-red'><a href='https://osf.io/pyh52/' target='_blank' 
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797617719730' target='_blank' class='doi-dimmed'>10.1177/0956797617719730</a></td>
+  <td><a href='https://doi.org/10.1177/0956797617719730' target='_blank' class='doi-dimmed'>10.1177/0956797617719730</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1419,7 +1419,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to Registered Report preregistered study protocol'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red'><a href='https://research.chicagobooth.edu/-/media/research/arc/docs/jar-annual-conference-papers/bernard-cade-hodge-accepted-proposal.pdf?la=en&hash=2B6FC6B13573F81718BE5A88F247C0CE630406E8' target='_blank' 
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> </td>
   <td><i>Journal of Accounting Research</i></td>
-  <td><a href='https://dx.doi.org/10.1111/1475-679X.12198' target='_blank' class='doi-dimmed'>10.1111/1475-679X.12198</a></td>
+  <td><a href='https://doi.org/10.1111/1475-679X.12198' target='_blank' class='doi-dimmed'>10.1111/1475-679X.12198</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1447,7 +1447,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to data files'></a>  <a href='https://osf.io/krwxn/' target='_blank' class='sprite sprite-reproducible-icon-medium' 
                       title='Go to reproducible code files'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797618761660' target='_blank' class='doi-dimmed'>10.1177/0956797618761660</a></td>
+  <td><a href='https://doi.org/10.1177/0956797618761660' target='_blank' class='doi-dimmed'>10.1177/0956797618761660</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -1462,7 +1462,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2014.12.019' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2014.12.019</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2014.12.019' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2014.12.019</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1478,7 +1478,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to data files'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.004' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.03.004</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.004' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.03.004</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1493,7 +1493,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2015.03.010' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2015.03.010</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2015.03.010' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2015.03.010</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1508,7 +1508,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.01.006' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.01.006</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.01.006' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.01.006</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1525,7 +1525,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.020' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.03.020</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.020' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.03.020</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1540,7 +1540,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2016.03.019' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.03.019</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2016.03.019' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2016.03.019</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1555,7 +1555,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2018.01.001' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2018.01.001</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2018.01.001' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2018.01.001</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1574,7 +1574,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='http://rsos.royalsocietypublishing.org/content/3/11/160431' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.160431' target='_blank' class='doi-dimmed'>10.1098/rsos.160431</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.160431' target='_blank' class='doi-dimmed'>10.1098/rsos.160431</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1591,7 +1591,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> <span class='label label-default'><a href='http://rsos.royalsocietypublishing.org/content/4/10/171172' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.171172' target='_blank' class='doi-dimmed'>10.1098/rsos.171172</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.171172' target='_blank' class='doi-dimmed'>10.1098/rsos.171172</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1609,7 +1609,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='http://rsos.royalsocietypublishing.org/content/4/9/160935' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.160935' target='_blank' class='doi-dimmed'>10.1098/rsos.160935</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.160935' target='_blank' class='doi-dimmed'>10.1098/rsos.160935</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1628,7 +1628,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='http://rsos.royalsocietypublishing.org/content/5/2/171678' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.171678' target='_blank' class='doi-dimmed'>10.1098/rsos.171678</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.171678' target='_blank' class='doi-dimmed'>10.1098/rsos.171678</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1646,7 +1646,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='http://rsos.royalsocietypublishing.org/content/4/12/170543' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Royal Society Open Science</i></td>
-  <td><a href='https://dx.doi.org/10.1098/rsos.170543' target='_blank' class='doi-dimmed'>10.1098/rsos.170543</a></td>
+  <td><a href='https://doi.org/10.1098/rsos.170543' target='_blank' class='doi-dimmed'>10.1098/rsos.170543</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1661,7 +1661,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414016633228' target='_blank' class='doi-dimmed'>10.1177/0010414016633228</a></td>
+  <td><a href='https://doi.org/10.1177/0010414016633228' target='_blank' class='doi-dimmed'>10.1177/0010414016633228</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1676,7 +1676,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414015626436' target='_blank' class='doi-dimmed'>10.1177/0010414015626436</a></td>
+  <td><a href='https://doi.org/10.1177/0010414015626436' target='_blank' class='doi-dimmed'>10.1177/0010414015626436</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1691,7 +1691,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Comparative Political Studies</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0010414015621072' target='_blank' class='doi-dimmed'>10.1177/0010414015621072</a></td>
+  <td><a href='https://doi.org/10.1177/0010414015621072' target='_blank' class='doi-dimmed'>10.1177/0010414015621072</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1710,7 +1710,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/26030' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.26030.001' target='_blank' class='doi-dimmed'>10.7554/eLife.26030.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.26030.001' target='_blank' class='doi-dimmed'>10.7554/eLife.26030.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1729,7 +1729,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/25306' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.25306.001' target='_blank' class='doi-dimmed'>10.7554/eLife.25306.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.25306.001' target='_blank' class='doi-dimmed'>10.7554/eLife.25306.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1748,7 +1748,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/21253' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.21253.001' target='_blank' class='doi-dimmed'>10.7554/eLife.21253.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.21253.001' target='_blank' class='doi-dimmed'>10.7554/eLife.21253.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1767,7 +1767,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/17584' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.17584.001' target='_blank' class='doi-dimmed'>10.7554/eLife.17584.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.17584.001' target='_blank' class='doi-dimmed'>10.7554/eLife.17584.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1786,7 +1786,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/17044' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.17044.001' target='_blank' class='doi-dimmed'>10.7554/eLife.17044.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.17044.001' target='_blank' class='doi-dimmed'>10.7554/eLife.17044.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1805,7 +1805,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/18173' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.18173.001' target='_blank' class='doi-dimmed'>10.7554/eLife.18173.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.18173.001' target='_blank' class='doi-dimmed'>10.7554/eLife.18173.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1825,7 +1825,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View preprint of this article.'>Preprint</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/21634' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.21634.001' target='_blank' class='doi-dimmed'>10.7554/eLife.21634.001</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.21634.001' target='_blank' class='doi-dimmed'>10.7554/eLife.21634.001</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1845,7 +1845,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View preprint of this article.'>Preprint</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/29747' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.29747' target='_blank' class='doi-dimmed'>10.7554/eLife.29747</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.29747' target='_blank' class='doi-dimmed'>10.7554/eLife.29747</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1865,7 +1865,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View preprint of this article.'>Preprint</a></span> <span class='label label-default'><a href='https://elifesciences.org/articles/30274' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>eLife</i></td>
-  <td><a href='https://dx.doi.org/10.7554/eLife.30274' target='_blank' class='doi-dimmed'>10.7554/eLife.30274</a></td>
+  <td><a href='https://doi.org/10.7554/eLife.30274' target='_blank' class='doi-dimmed'>10.7554/eLife.30274</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1880,7 +1880,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000286' target='_blank' class='doi-dimmed'>10.1027/1618-3169/a000286</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000286' target='_blank' class='doi-dimmed'>10.1027/1618-3169/a000286</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1895,7 +1895,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000364' target='_blank' class='doi-dimmed'>10.1027/1618-3169/a000364</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000364' target='_blank' class='doi-dimmed'>10.1027/1618-3169/a000364</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1910,7 +1910,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to Registered Report preregistered study protocol'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red'><a href='https://osf.io/h6ext/register/565fb3678c5e4a66b5582f67' target='_blank' 
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> </td>
   <td><i>Experimental Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1618-3169/a000372' target='_blank' class='doi-dimmed'>10.1027/1618-3169/a000372</a></td>
+  <td><a href='https://doi.org/10.1027/1618-3169/a000372' target='_blank' class='doi-dimmed'>10.1027/1618-3169/a000372</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -1929,7 +1929,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://econtent.hogrefe.com/doi/10.1027/1864-1105/a000210' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Journal of Media Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-1105/a000210' target='_blank' class='doi-dimmed'>10.1027/1864-1105/a000210</a></td>
+  <td><a href='https://doi.org/10.1027/1864-1105/a000210' target='_blank' class='doi-dimmed'>10.1027/1864-1105/a000210</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1948,7 +1948,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-info-purple'><a href='https://psyarxiv.com/6mmra/' target='_blank' 
                       class='black' title='View preprint of this article.'>Preprint</a></span> </td>
   <td><i>Journal of Media Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-1105/a000209' target='_blank' class='doi-dimmed'>10.1027/1864-1105/a000209</a></td>
+  <td><a href='https://doi.org/10.1027/1864-1105/a000209' target='_blank' class='doi-dimmed'>10.1027/1864-1105/a000209</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -1993,7 +1993,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-default'><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4976003/' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616649604' target='_blank' class='doi-dimmed'>10.1177/0956797616649604</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616649604' target='_blank' class='doi-dimmed'>10.1177/0956797616649604</a></td>
   <td>rs</td>
   <td></td>
   <td>prereg</td>
@@ -2022,7 +2022,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-info-purple'><a href='https://osf.io/w389p/' target='_blank' 
                       class='black' title='View preprint of this article.'>Preprint</a></span> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797614553121' target='_blank' class='doi-dimmed'>10.1177/0956797614553121</a></td>
+  <td><a href='https://doi.org/10.1177/0956797614553121' target='_blank' class='doi-dimmed'>10.1177/0956797614553121</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2048,7 +2048,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to study materials files'></a>  <a href='https://osf.io/a6hfd/' target='_blank' class='sprite sprite-preregisteredplus-medium' 
                      title='Go to preregistered study protocol'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616638307' target='_blank' class='doi-dimmed'>10.1177/0956797616638307</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616638307' target='_blank' class='doi-dimmed'>10.1177/0956797616638307</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2075,7 +2075,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Go to preregistered study protocol'></a>  <a href='https://osf.io/c2gaf/' target='_blank' class='sprite sprite-data-medium' 
                       title='Go to data files'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797615572909' target='_blank' class='doi-dimmed'>10.1177/0956797615572909</a></td>
+  <td><a href='https://doi.org/10.1177/0956797615572909' target='_blank' class='doi-dimmed'>10.1177/0956797615572909</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2093,7 +2093,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://www.frontiersin.org/articles/10.3389/fpsyg.2014.00875/full' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.00875' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2014.00875</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.00875' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2014.00875</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2110,7 +2110,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://www.frontiersin.org/articles/10.3389/fpsyg.2015.00335/full' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00335' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2015.00335</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00335' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2015.00335</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2129,7 +2129,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://www.frontiersin.org/articles/10.3389/fpsyg.2014.00786/full' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.00786' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2014.00786</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.00786' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2014.00786</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2148,7 +2148,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://www.frontiersin.org/articles/10.3389/fpsyg.2014.01035/full' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2014.01035' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2014.01035</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2014.01035' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2014.01035</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2166,7 +2166,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://www.frontiersin.org/articles/10.3389/fpsyg.2015.00672/full' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00672' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2015.00672</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00672' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2015.00672</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2185,7 +2185,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://www.frontiersin.org/articles/10.3389/fpsyg.2015.00494/full' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Frontiers in Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.3389/fpsyg.2015.00494' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2015.00494</a></td>
+  <td><a href='https://doi.org/10.3389/fpsyg.2015.00494' target='_blank' class='doi-dimmed'>10.3389/fpsyg.2015.00494</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2202,7 +2202,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2017.1341178' target='_blank' class='doi-dimmed'>10.1080/23743603.2017.1341178</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2017.1341178' target='_blank' class='doi-dimmed'>10.1080/23743603.2017.1341178</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2219,7 +2219,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-info-red'><a href='https://osf.io/ut9jv/' target='_blank' 
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2017.1341186' target='_blank' class='doi-dimmed'>10.1080/23743603.2017.1341186</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2017.1341186' target='_blank' class='doi-dimmed'>10.1080/23743603.2017.1341186</a></td>
   <td></td>
   <td></td>
   <td>prereg</td>
@@ -2235,7 +2235,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Registered Report preregistered study protocol not (yet) publicly available'></a>  <a class='sprite sprite-materials-medium-unavailable' title='Open data information is not available'></a> <span class='label label-info-red' 
                     title='Registered Report preregistered study protocol not (yet) publicly available.'>Registered Report</span> </td>
   <td><i>Comprehensive Results in Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/23743603.2016.1248081' target='_blank' class='doi-dimmed'>10.1080/23743603.2016.1248081</a></td>
+  <td><a href='https://doi.org/10.1080/23743603.2016.1248081' target='_blank' class='doi-dimmed'>10.1080/23743603.2016.1248081</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2253,7 +2253,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://econtent.hogrefe.com/doi/10.1027/1864-9335/a000189' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000189' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000189</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000189' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000189</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2272,7 +2272,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://econtent.hogrefe.com/doi/full/10.1027/1864-9335/a000191' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000191' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000191</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000191' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000191</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2290,7 +2290,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://econtent.hogrefe.com/doi/full/10.1027/1864-9335/a000190' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000190' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000190</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000190' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000190</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2307,7 +2307,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://econtent.hogrefe.com/doi/full/10.1027/1864-9335/a000184' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1027/1864-9335/a000184' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000184</a></td>
+  <td><a href='https://doi.org/10.1027/1864-9335/a000184' target='_blank' class='doi-dimmed'>10.1027/1864-9335/a000184</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2326,7 +2326,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-info-purple'><a href='https://psyarxiv.com/tpx5c/' target='_blank' 
                       class='black' title='View preprint of this article.'>Preprint</a></span> </td>
   <td><i>Journal of Research in Personality</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.jrp.2017.10.005' target='_blank' class='doi-dimmed'>10.1016/j.jrp.2017.10.005</a></td>
+  <td><a href='https://doi.org/10.1016/j.jrp.2017.10.005' target='_blank' class='doi-dimmed'>10.1016/j.jrp.2017.10.005</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2343,7 +2343,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to data files'></a> <span class='label label-info-red'><a href='https://osf.io/rv54j/' target='_blank' 
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> </td>
   <td><i>Cognition and Emotion</i></td>
-  <td><a href='https://dx.doi.org/10.1080/02699931.2018.1429389' target='_blank' class='doi-dimmed'>10.1080/02699931.2018.1429389</a></td>
+  <td><a href='https://doi.org/10.1080/02699931.2018.1429389' target='_blank' class='doi-dimmed'>10.1080/02699931.2018.1429389</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2360,7 +2360,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to data files'></a>  <a href='https://osf.io/wdvpz/' target='_blank' class='sprite sprite-reproducible-icon-medium' 
                       title='Go to reproducible code files'></a> </td>
   <td><i>Perception</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0301006617720831' target='_blank' class='doi-dimmed'>10.1177/0301006617720831</a></td>
+  <td><a href='https://doi.org/10.1177/0301006617720831' target='_blank' class='doi-dimmed'>10.1177/0301006617720831</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2378,7 +2378,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='View preprint of this article.'>Preprint</a></span> <span class='label label-default'><a href='https://peerj.com/articles/837/' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>PeerJ</i></td>
-  <td><a href='https://dx.doi.org/10.7717/peerj.837' target='_blank' class='doi-dimmed'>10.7717/peerj.837</a></td>
+  <td><a href='https://doi.org/10.7717/peerj.837' target='_blank' class='doi-dimmed'>10.7717/peerj.837</a></td>
   <td></td>
   <td>om</td>
   <td></td>
@@ -2405,7 +2405,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                      title='Go to preregistered study protocol'></a>  <a href='https://osf.io/rh2dq/' target='_blank' class='sprite sprite-data-medium' 
                       title='Go to data files'></a> </td>
   <td><i>Psychological Science</i></td>
-  <td><a href='https://dx.doi.org/10.1177/0956797616678930' target='_blank' class='doi-dimmed'>10.1177/0956797616678930</a></td>
+  <td><a href='https://doi.org/10.1177/0956797616678930' target='_blank' class='doi-dimmed'>10.1177/0956797616678930</a></td>
   <td>rs</td>
   <td>om</td>
   <td>prereg</td>
@@ -2439,7 +2439,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to data files'></a>  <a href='https://osf.io/b94yx/' target='_blank' class='sprite sprite-reproducible-icon-medium' 
                       title='Go to reproducible code files'></a> </td>
   <td><i>Psychonomic Bulletin & Review</i></td>
-  <td><a href='https://dx.doi.org/10.3758/s13423-018-1489-7' target='_blank' class='doi-dimmed'>10.3758/s13423-018-1489-7</a></td>
+  <td><a href='https://doi.org/10.3758/s13423-018-1489-7' target='_blank' class='doi-dimmed'>10.3758/s13423-018-1489-7</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2458,7 +2458,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       class='black' title='Go to Registered Report preregistered study protocol.'>Registered Report</a></span> <span class='label label-default'><a href='https://www.sciencedirect.com/science/article/pii/S0010945218300583' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Cortex</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.cortex.2018.02.009' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2018.02.009</a></td>
+  <td><a href='https://doi.org/10.1016/j.cortex.2018.02.009' target='_blank' class='doi-dimmed'>10.1016/j.cortex.2018.02.009</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2474,7 +2474,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to data files'></a>  <a href='https://osf.io/v72ca/' target='_blank' class='sprite sprite-reproducible-icon-medium' 
                       title='Go to reproducible code files'></a> </td>
   <td><i>The Journal of Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1080/00224545.2017.1341374' target='_blank' class='doi-dimmed'>10.1080/00224545.2017.1341374</a></td>
+  <td><a href='https://doi.org/10.1080/00224545.2017.1341374' target='_blank' class='doi-dimmed'>10.1080/00224545.2017.1341374</a></td>
   <td></td>
   <td>om</td>
   <td></td>
@@ -2502,7 +2502,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-info-purple'><a href='https://psyarxiv.com/tdvy7/' target='_blank' 
                       class='black' title='View preprint of this article.'>Preprint</a></span> </td>
   <td><i>Journal of Experimental Social Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1016/j.jesp.2017.07.002' target='_blank' class='doi-dimmed'>10.1016/j.jesp.2017.07.002</a></td>
+  <td><a href='https://doi.org/10.1016/j.jesp.2017.07.002' target='_blank' class='doi-dimmed'>10.1016/j.jesp.2017.07.002</a></td>
   <td>rs</td>
   <td></td>
   <td>prereg</td>
@@ -2549,7 +2549,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-default'><a href='https://www.nature.com/articles/sdata2016129' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Scientific Data</i></td>
-  <td><a href='https://dx.doi.org/10.1038/sdata.2016.129' target='_blank' class='doi-dimmed'>10.1038/sdata.2016.129</a></td>
+  <td><a href='https://doi.org/10.1038/sdata.2016.129' target='_blank' class='doi-dimmed'>10.1038/sdata.2016.129</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2567,7 +2567,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-default'><a href='https://www.nature.com/articles/sdata2016120' target='_blank' 
                       class='black' title='View interactive HTML version of this article.'>HTML</a></span> </td>
   <td><i>Scientific Data</i></td>
-  <td><a href='https://dx.doi.org/10.1038/sdata.2016.120' target='_blank' class='doi-dimmed'>10.1038/sdata.2016.120</a></td>
+  <td><a href='https://doi.org/10.1038/sdata.2016.120' target='_blank' class='doi-dimmed'>10.1038/sdata.2016.120</a></td>
   <td></td>
   <td>om</td>
   <td>prereg</td>
@@ -2584,7 +2584,7 @@ Basic 4 (at submission)</a><a class='sprite sprite-disclosure-medium-available'>
                       title='Go to reproducible code files'></a> <span class='label label-info-purple'><a href='https://osf.io/m85bp/' target='_blank' 
                       class='black' title='View preprint of this article.'>Preprint</a></span> </td>
   <td><i>Evolutionary Psychology</i></td>
-  <td><a href='https://dx.doi.org/10.1177/1474704918776748' target='_blank' class='doi-dimmed'>10.1177/1474704918776748</a></td>
+  <td><a href='https://doi.org/10.1177/1474704918776748' target='_blank' class='doi-dimmed'>10.1177/1474704918776748</a></td>
   <td></td>
   <td>om</td>
   <td></td>

--- a/old-stuff/index_backup[2018-04-22].html
+++ b/old-stuff/index_backup[2018-04-22].html
@@ -23622,7 +23622,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
 						  <td style="vertical-align:top;"><a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Justifications Shape Ethical Blind Spots</td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23700,7 +23700,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23738,7 +23738,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Implicit Social Biases in People With Autism</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23830,7 +23830,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23866,7 +23866,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
 							<td style="vertical-align:top;"><a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23889,7 +23889,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">

--- a/old-stuff/index_backup[2018-04-30].html
+++ b/old-stuff/index_backup[2018-04-30].html
@@ -23647,7 +23647,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
 						  <td style="vertical-align:top;"><a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Justifications Shape Ethical Blind Spots</td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23723,7 +23723,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23754,7 +23754,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Implicit Social Biases in People With Autism</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23846,7 +23846,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23882,7 +23882,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
 							<td style="vertical-align:top;"><a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23919,7 +23919,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Journal of Research in Personality</i></td>
 							<td style="vertical-align:top;"><a href=' https://static1.squarespace.com/static/594641bbe3df28301b1a0493/t/5970b5c8f5e2311272d3b4f0/1500558794416/2017+%28in+press%29_Campbell+et+al_JRP_Replication+of+Murray+et+al+2002.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Self-esteem, relationship threat, and dependency regulation: Independent replication of Murray, Rose, Bellavia, Holmes, and Kusche (2002) Study 3</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23942,7 +23942,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">

--- a/old-stuff/index_backup[2018-05-02].html
+++ b/old-stuff/index_backup[2018-05-02].html
@@ -23647,7 +23647,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
 						  <td style="vertical-align:top;"><a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Justifications Shape Ethical Blind Spots</td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23723,7 +23723,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23754,7 +23754,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Implicit Social Biases in People With Autism</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23846,7 +23846,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;"><a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -23882,7 +23882,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
 							<td style="vertical-align:top;"><a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23919,7 +23919,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>Journal of Research in Personality</i></td>
 							<td style="vertical-align:top;"><a href=' https://static1.squarespace.com/static/594641bbe3df28301b1a0493/t/5970b5c8f5e2311272d3b4f0/1500558794416/2017+%28in+press%29_Campbell+et+al_JRP_Replication+of+Murray+et+al+2002.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Self-esteem, relationship threat, and dependency regulation: Independent replication of Murray, Rose, Bellavia, Holmes, and Kusche (2002) Study 3</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -23942,7 +23942,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">

--- a/old-stuff/index_backup[2018-05-06].html
+++ b/old-stuff/index_backup[2018-05-06].html
@@ -23554,7 +23554,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 						  <td style="vertical-align:top;"><a href=' https://www.researchgate.net/profile/Andrea_Pittarello/publication/270757442_Justifications_Shape_Ethical_Blind_Spots/links/553200d20cf20ea0a071c477.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Justifications Shape Ethical Blind Spots</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						  <td>rs</td>
 						  <td>om</td>
 						  <td>prereg</td>
@@ -23625,7 +23625,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4504740/pdf/nihms678183.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -23661,7 +23661,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href=' http://www.its.caltech.edu/~dstanley/publications/2015_Birmingham_Stanley_et_al_wSupp.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Implicit Social Biases in People With Autism</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td></td>
@@ -23756,7 +23756,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://pdfs.semanticscholar.org/6d2e/77ffa574ef2d5fa9b7ff93c34422e9e749e1.pdf ' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -23790,7 +23790,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://rebeccawillen.files.wordpress.com/2018/02/as1013805681295601401182419574_content_1.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 							<td>rs</td>
 							<td></td>
 							<td></td>
@@ -23832,7 +23832,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href=' https://static1.squarespace.com/static/594641bbe3df28301b1a0493/t/5970b5c8f5e2311272d3b4f0/1500558794416/2017+%28in+press%29_Campbell+et+al_JRP_Replication+of+Murray+et+al+2002.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Self-esteem, relationship threat, and dependency regulation: Independent replication of Murray, Rose, Bellavia, Holmes, and Kusche (2002) Study 3 <span class="label label-info-teal"><a href="https://psyarxiv.com/5suda/" target="_blank" class="black" title="View preprint of this article.">Preprint</a></span></td>
 							<td style="vertical-align:top;"><i>Journal of Research in Personality</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1016/j.jrp.2017.04.001">10.1016/j.jrp.2017.04.001</a></td>
 							<td>rs</td>
 							<td>om</td>
 							<td>prereg</td>
@@ -23860,7 +23860,7 @@ contributions of researchers who devote their time to replicating the work of ot
 							</td>
 							<td style="vertical-align:top;"><a href='https://www.researchgate.net/profile/Katherine_Collison/publication/322685405_Examining_the_Effects_of_Controlling_for_Shared_Variance_among_the_Dark_Triad_Using_Meta-analytic_Structural_Equation_Modelling_Dark_Triad_metaSEM/links/5a6e7618458515d407585359/Examining-the-Effects-of-Controlling-for-Shared-Variance-among-the-Dark-Triad-Using-Meta-analytic-Structural-Equation-Modelling-Dark-Triad-metaSEM.pdf' target='_blank' class='sprite sprite-pdf-icon-medium'></a> Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 							<td></td>
 							<td>om</td>
 							<td></td>

--- a/sandbox.html
+++ b/sandbox.html
@@ -357,7 +357,7 @@
 							</td>
 						  <td style="vertical-align:top;"><i>Psychological Science</i></td>
 						  <td style="vertical-align:top;">Justifications Shape Ethical Blind Spots</td>
-						  <td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
+						  <td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615571018">10.1177/0956797615571018</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -436,7 +436,7 @@
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;">Grouping Promotes Equality: The Effect of Recipient Grouping on Allocation of Limited Medical Resources</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615583978">10.1177/0956797615583978</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -475,7 +475,7 @@
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;">Implicit Social Biases in People With Autism</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797615595607">10.1177/0956797615595607</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -567,7 +567,7 @@
 							</td>
 							<td style="vertical-align:top;"><i>Psychological Science</i></td>
 							<td style="vertical-align:top;">Why Do People Tend to Infer 'Ought' From 'Is'? The Role of Biases in Explanation</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1177/0956797616650875">10.1177/0956797616650875</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -597,7 +597,7 @@
 							</td>
 							<td style="vertical-align:top;"><i>Legal and Criminological Psychology</i></td>
 							<td style="vertical-align:top;">Offenders’ uncoerced false confessions: A new application of statement analysis?</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1111/j.2044-8333.2011.02018.x">10.1111/j.2044-8333.2011.02018.x</a></td>
 						</tr>
 						<tr>
 						  <td style="white-space: nowrap">
@@ -621,7 +621,7 @@
 							</td>
 							<td style="vertical-align:top;"><i>European Journal of Personality</i></td>
 							<td style="vertical-align:top;">Examining the Effects of Controlling for Shared Variance among the Dark Triad Using Meta-analytic Structural Equation Modelling</td>
-							<td style="vertical-align:top;"><a target="_blank" href="https://dx.doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
+							<td style="vertical-align:top;"><a target="_blank" href="https://doi.org/10.1002/per.2137">10.1002/per.2137</a></td>
 						</tr>
 						<tr>
 							<td colspan="4" style="padding-top:0px;padding-bottom:0px;">
@@ -701,7 +701,7 @@
 				<font size="6px"><a href="http://pps.sagepub.com/content/9/5/556.full.pdf+html" target="_blank">RRR1 & RRR2: Alogna et al., ..., Zwaan (2014)</a></font>&nbsp;&nbsp;<a href="http://pps.sagepub.com/content/9/5/556.full.pdf+html" target="_blank"><img src="logos/pdf-icon.gif"></a><br>
 				<font size="6px">Schooler & Engstler-Schooler (1990) -- Replications (23) </font>&nbsp;&nbsp;<a class="twitter-share-button" href="https://twitter.com/intent/tweet?text=Check%20out%20curated%20replications%20of%20verbal%20overshadowing%20RRR&amp;url=http%3A%2F%2Fcuratescience.org%2F&#35s%26e%2Ds&amp;via=curatescience">Tweet</a><br>
 				<font size="5px">Verbal overshadowing of visual memories: Some things are better left unsaid</font><br>
-				DOI:<a href='https://dx.doi.org/10.1016/0010-0285(90)90003-M' target="_blank">10.1016/0010-0285(90)90003-M</a>&nbsp;&nbsp;<a href="https://www.researchgate.net/profile/Jonathan_Schooler/publication/20861308_Verbal_overshadowing_of_visual_memories_Some_things_are_better_left_unsaid._Cognit._Psychol._22_36-71/links/5611ddba08ae6b29b49e3994.pdf" target="_blank"><img src="logos/pdf-icon.gif"></a></p>
+				DOI:<a href='https://doi.org/10.1016/0010-0285(90)90003-M' target="_blank">10.1016/0010-0285(90)90003-M</a>&nbsp;&nbsp;<a href="https://www.researchgate.net/profile/Jonathan_Schooler/publication/20861308_Verbal_overshadowing_of_visual_memories_Some_things_are_better_left_unsaid._Cognit._Psychol._22_36-71/links/5611ddba08ae6b29b49e3994.pdf" target="_blank"><img src="logos/pdf-icon.gif"></a></p>
 				
 				<table ><tbody>
 					<tr>
@@ -769,7 +769,7 @@
 				<font size="6px"><a href="http://pps.sagepub.com/content/9/5/556.full.pdf+html" target="_blank">RRR1 & RRR2: Alogna et al., ..., Zwaan (2014)</a></font>&nbsp;&nbsp;<a href="http://pps.sagepub.com/content/9/5/556.full.pdf+html" target="_blank"><img src="logos/pdf-icon.gif"></a><br>
 				<font size="6px">Schooler & Engstler-Schooler (1990) -- Replications (23) </font>&nbsp;&nbsp;<a class="twitter-share-button" href="https://twitter.com/intent/tweet?text=Check%20out%20curated%20replications%20of%20verbal%20overshadowing%20RRR&amp;url=http%3A%2F%2Fcuratescience.org%2F&#35s%26e%2Ds&amp;via=curatescience">Tweet</a><br>
 				<font size="5px">Verbal overshadowing of visual memories: Some things are better left unsaid</font><br>
-				DOI:<a href='https://dx.doi.org/10.1016/0010-0285(90)90003-M' target="_blank">10.1016/0010-0285(90)90003-M</a>&nbsp;&nbsp;<a href="https://www.researchgate.net/profile/Jonathan_Schooler/publication/20861308_Verbal_overshadowing_of_visual_memories_Some_things_are_better_left_unsaid._Cognit._Psychol._22_36-71/links/5611ddba08ae6b29b49e3994.pdf" target="_blank"><img src="logos/pdf-icon.gif"></a></p>
+				DOI:<a href='https://doi.org/10.1016/0010-0285(90)90003-M' target="_blank">10.1016/0010-0285(90)90003-M</a>&nbsp;&nbsp;<a href="https://www.researchgate.net/profile/Jonathan_Schooler/publication/20861308_Verbal_overshadowing_of_visual_memories_Some_things_are_better_left_unsaid._Cognit._Psychol._22_36-71/links/5611ddba08ae6b29b49e3994.pdf" target="_blank"><img src="logos/pdf-icon.gif"></a></p>
 				
 				<table ><tbody>
 					<tr>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links in the `.html` & `.csv` files and the code that generates new DOI links in the `.R`, but I I ignored the PDF files.

Cheers!